### PR TITLE
Added support for printing File Name, Line Number.

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,9 +18,9 @@ log.info('gateway', 'Check', null)
 You can set log format
 
 ```
-// possible options are "ram" , "ts" "uptime" "pid", "count"
+// possible options are "ram" , "ts" "uptime" "pid", "count",
+// and "__FUNC__", "__FILE__", "__LINE__", "__COLM__". C Forever. :D
 log.setLogFormat('<%= ts %> [<%= uptime %>] ');
-
 ```
 
 You can set Log level
@@ -39,7 +39,6 @@ log.setErr('/path/of/file/to/write/Error/messages')
 
 // to redirect back to STDERR
 log.setErr()
-
 ```
 
 ## Features

--- a/test.js
+++ b/test.js
@@ -19,10 +19,18 @@ LOG.setLevel('verbose');
 LOG.setErr();
 LOG.error('TEST', 'Check', null, [], [ 1,2,'a',], {}, undefined, { 'a' : 1 , 'b' : 2}, function(){});
 
+LOG.setLogFormat('In: <%= __FUNC__ %>() At: <%= __FILE__ %>:<%= __LINE__ %>: ');
+function testFunction () {
+    LOG.info('TEST', 'Check', null, [], [ 1,2,'a',], {}, undefined, { 'a' : 1 , 'b' : 2}, function(){});
+    LOG.error('TEST', 'Check', null, [], [ 1,2,'a',], {}, undefined, { 'a' : 1 , 'b' : 2}, function(){});
+}
+
+testFunction();
+LOG.info('TEST', 'Check', null, [], [ 1,2,'a',], {}, undefined, { 'a' : 1 , 'b' : 2}, function(){});
+LOG.error('TEST', 'Check', null, [], [ 1,2,'a',], {}, undefined, { 'a' : 1 , 'b' : 2}, function(){});
 
 LOG.setOut(PATH.join(__dirname, 'testout.log'));
 LOG.info('TEST in file', 'Check', null, [], [ 1,2,'a',], {}, undefined, { 'a' : 1 , 'b' : 2}, function(){});
 
 LOG.setErr(PATH.join(__dirname, 'testerror.log'));
 LOG.error('TEST in file', 'Check', null, [], [ 1,2,'a',], {}, undefined, { 'a' : 1 , 'b' : 2}, function(){});
-


### PR DESCRIPTION
- Hijack the prepareStackTrace
- captureStackTrace omitting the first known LGR.function that will be
  called
- restore the prepareStackTrace to the original
- Use V8's StackTrace APIs to explore the call site objects (frames)
  captured.