### PR TITLE
moving to Paytm's fork of npmlog

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,5 @@
+before_install:
+    - npm install -g npm@3
 language: node_js
 node_js:
   - "0.10.24"

--- a/README.md
+++ b/README.md
@@ -60,13 +60,14 @@ You can add your own custom levels
 
 The level name and priority are mandatory arguments, and
 lgr will throw an error if either is missing. You can
-define your own style and prefix, npm style.
+define your own style and prefix, npm style, with an additional
+stream parameter.
 ```
 // mandatory arguments
 log.addLevel('wall', 3500);
 
 // optional arguments
-log.addLevel('hell', 6666, {fg: 'black', bg: 'red'}, 'HELL!');
+log.addLevel('hell', 6666, {fg: 'black', bg: 'red'}, 'HELL!', process.stderr);
 ```
 
 You can Redirect outout / error to log files
@@ -84,6 +85,7 @@ log.setErr()
 
 ## Features
 - All of npmlog as of now
+- Not an EventEmitter (this speeds up things, as we no longer need to emit events and register listeners).
 - A starting timestamp when logger was initiated. Gives 2 timestamps , one global and another the starting timestamp of the process.
 - The Extra information in Logs is thrown out in Formatted Strings like Nginx Logs
 

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   },
   "homepage": "https://github.com/paytm/lgr",
   "dependencies": {
-    "npmlog": "~1.2.1",
+    "npmlog": "https://github.com/paytm/npmlog",
     "lodash": "~3.10.1",
     "moment": "~2.10.3"
   },

--- a/test.js
+++ b/test.js
@@ -70,6 +70,7 @@ LOG.setLevel('silly');
 LOG.silly('SILL', "O Yaara silly silly");
 LOG.info('SILL', 'LEVEL', LOG.getLevel());
 
+LOG.critical('Woah!', "Is this even printing?");
 
 LOG.setLogFormat('<%= ts %> [<%= uptime %>] ');
 testFunction();


### PR DESCRIPTION
- Removed NPMLOG.on(), as npmlog is not an EventEmitter now.
- Updated npm for travis, as it's own version was breaking builds.
- addLevel() can take an additional optional parameter, the stream
  to write the logs to, for every level. process.stderr for error
  and critical by default.