### PR TITLE
Let's not cheat on travis builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,7 @@
-before_install:
-    - npm install -g npm@3
 language: node_js
 node_js:
   - "0.10.24"
+  - "0.12.4"
   - "4.2.3"
 
 # Send coverage data to Coveralls


### PR DESCRIPTION
Travis did indeed report a build error earlier, when using `https://` url for npmlog.
I did not debug the error, but instead found a workaround: update to latest npm before building.

Since this approach is not backward compatible (we are still using older versions of node and npm in production), let's remove this hack, so that Travis would indeed report build errors.